### PR TITLE
fix: --version/--help flags + startup timing observability for #29 reconnect diagnostics

### DIFF
--- a/che-telegram-all-mcp/CHANGELOG.md
+++ b/che-telegram-all-mcp/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.5.5] - 2026-05-09
+
+CLI fast-exit dispatcher + startup observability for `/mcp` reconnect diagnostics.
+
+Health-check entry point + per-phase timing instrumentation. Does **not** directly fix Claude Code's `/mcp` "Failed to reconnect" symptom — the root cause is the interaction of wrapper-side cold-start latency, Claude Code's reconnect timeout, and 233MB universal Mach-O dynamic linking. This release equips wrappers and humans to diagnose which contributor dominates in their environment, and gives `psychquant-claude-plugins/che-telegram-mcp-wrapper.sh` a sub-second `--version` probe to replace its GitHub API curl on every spawn.
+
+### Added
+- **`--version` / `-v` flag (#29 S1)**: Prints `che-telegram-all-mcp 0.5.5` to stdout and exits 0 in <10ms warm / <1s cold, **before** `await CheTelegramAllMCPServer()` is constructed (no TDLib framework load, no Application Support directory creation, no MCP handler registration). Production benchmark vs. previous behavior: ≥10s → 0.008s warm, a >1000× speedup for wrapper / monitoring health checks.
+- **`--help` / `-h` flag (#29 S2)**: Prints multi-line help to stdout and exits 0. Help text explicitly states "Primary mode is stdio JSON-RPC — connect via Claude Code's MCP plugin configuration, not by invoking interactively" so callers don't mistake the binary for an interactive CLI. Documents all supported environment variables including `CHE_TELEGRAM_LOG_STARTUP=1` for diagnostic discoverability.
+- **`CHE_TELEGRAM_LOG_STARTUP=1` env-gated startup log (#29 S3)**: When set, `CheTelegramAllMCPServer.init` emits four lines to **stderr** (stdout is reserved for MCP JSON-RPC traffic) — `[startup] tdlib_init=N.NNNs`, `[startup] tools_define=N.NNNs`, `[startup] register_handlers=N.NNNs`, `[startup] total=N.NNNs`. Default off. `DispatchTime.now()` for monotonic timing with saturating subtract `&-` for clock-rewind defense.
+- **Failure-path observability for startup log (#29 verify F2)**: `tdlib_init` phase wraps in `do/catch` — if `try await TDLibClient()` throws after a slow init, emits `[startup] tdlib_init_FAILED=N.NNNs` and `[startup] total_FAILED=N.NNNs` to stderr **before** re-throwing. Without this, the `if logStartup` block was unreachable on throw, leaving the failure path (the case the user is most likely diagnosing) silent.
+- **`shouldLogStartup(env:)` testable predicate (#29 verify F4)**: Extracted env-var truthy check from `init` to a file-scope helper accepting an env dictionary explicitly. Strict `== "1"` contract — does not accept `"true"`, `"yes"`, `"TRUE"`, etc. Matches help text exactly to avoid documentation drift.
+
+### Fixed
+- **Unknown flag rejection (#29 verify F3)**: Previously, typos like `--versoin` fell through `default: return .runServer` and silently entered stdio MCP mode, hanging on stdin — exactly the failure pattern this PR set out to avoid. `CLIBootstrap.parse` now returns `.unknownFlag(_)` for any `-`-prefixed argument that doesn't match a recognized flag; `main.swift` writes `Error: unknown flag '<flag>'. Run with --help for usage.` to stderr and exits 2 (POSIX misuse convention, distinct from exit 1 = runtime error). Non-flag positional arguments (no leading `-`) still fall through to `.runServer` to preserve backward compat for callers passing paths or config names.
+
+### Refactored
+- **`logStartupDuration` visibility `private` → `internal` (#29 verify F4)**: Was file-scope `private`. Promoted to module-internal so `shouldLogStartup` predicate test in `CheTelegramAllMCPTests` can co-exist in the same module without exposing the helper publicly.
+- **`CLIBootstrap` enum + parser in `CheTelegramAllMCPCore` (#29 S1+S2)**: Argv parsing extracted from `main.swift` (which now becomes a 4-case dispatch) into a pure `CLIBootstrap.parse(_: [String]) -> CLIAction` function in `CheTelegramAllMCPCore` so it is reachable by `CheTelegramAllMCPTests` for unit testing without spawning a subprocess. `CLIAction` is `Equatable` so tests can use `XCTAssertEqual`.
+
+### Test
+- **25 new tests in `CLIBootstrapTests`**: 10 parser tests (long/short version+help, no-args, non-flag positional, empty argv defensiveness, helpText invariants for version constant + stdio mention + env var name); 6 env predicate tests (`shouldLogStartup` strict `"1"` contract — true on `"1"`, false on unset / `""` / `"0"` / `"true"` / `"TRUE"`); 5 unknown-flag rejection tests (long typo, short typo, single `-`, case-sensitive `-V` ≠ `-v`); 4 subprocess integration tests via `Process` API + `Bundle(for:)` path resolution (asserts exit code + stdout / stderr for `--version`, `-v`, `--help`, and unknown flag exit 2). Subprocess tests skip cleanly when binary not built.
+- **Test count: 180 → 216 (+36, all in `CheTelegramAllMCPTests`)**.
+
+### Production leverage (out of repo)
+This release alone does not change end-user experience. Real leverage requires the consumer side of the contract:
+- **`psychquant-claude-plugins/.../che-telegram-all-mcp-wrapper.sh` should adopt `$BINARY --version` health check** instead of (or in addition to) the current `curl` to GitHub Releases API for version verification. The wrapper currently fork-execs `curl --max-time 30` twice on every spawn even when `$INSTALLED_VERSION == $DESIRED_VERSION` — replacing that with a sub-second binary call removes a major source of cold-start latency that contributes to Claude Code's `/mcp` "Failed to reconnect" symptom.
+- **Sister concerns surfaced during diagnosis** (out of `che-msg` scope, tracked separately): wrapper should add a stderr log file at `~/Library/Logs/CheTelegramAllMCP/wrapper.log` for post-mortem debugging; Claude Code's MCP reconnect timeout vs. 233MB binary cold-start interaction warrants upstream feedback; potential TDLib lock-file detection if `~/Library/Application Support/che-telegram-all-mcp/tdlib/` accumulates stale state from crashed wrappers.
+
+### Honest constraint
+This PR is **observability + a fast health-check entry point**, not a direct fix for the reported `/mcp` reconnect timeout. Verifying `--version` exits 0, `[startup]` lines emit when env is set, and `--versoin` typos exit 2 — does **not** prove the original "Failed to reconnect" message goes away in production. That requires the wrapper-side change above plus deploy + multi-session reproduction, neither of which this repo can deliver alone. The honest scope is "build the diagnostic and integration surface that future fixes will plug into".
+
 ## [0.5.4] - 2026-04-27
 
 Input hardening + handler glue testability + log-format polish.

--- a/che-telegram-all-mcp/Sources/CheTelegramAllMCP/main.swift
+++ b/che-telegram-all-mcp/Sources/CheTelegramAllMCP/main.swift
@@ -10,6 +10,13 @@ case .showVersion:
 case .showHelp:
     print(CLIBootstrap.helpText)
     exit(0)
+case .unknownFlag(let flag):
+    // Typo on a recognized flag (e.g. `--versoin`) — fail loud so the user
+    // sees their mistake instead of silently entering stdio MCP mode and
+    // hanging on stdin. Exit 2 (POSIX convention: misuse of CLI), distinct
+    // from exit 1 (runtime error in server flow below).
+    fputs("Error: unknown flag '\(flag)'. Run with --help for usage.\n", stderr)
+    exit(2)
 case .runServer:
     do {
         let server = try await CheTelegramAllMCPServer()

--- a/che-telegram-all-mcp/Sources/CheTelegramAllMCP/main.swift
+++ b/che-telegram-all-mcp/Sources/CheTelegramAllMCP/main.swift
@@ -1,10 +1,21 @@
 import Foundation
 import CheTelegramAllMCPCore
 
-do {
-    let server = try await CheTelegramAllMCPServer()
-    try await server.run()
-} catch {
-    fputs("Error: \(error)\n", stderr)
-    exit(1)
+// Argv dispatch BEFORE any TDLib/MCP init so --version / --help return in
+// sub-second wall-clock without paying the ~10s cold-start cost (#29).
+switch CLIBootstrap.parse(CommandLine.arguments) {
+case .showVersion:
+    print("che-telegram-all-mcp \(CLIBootstrap.version)")
+    exit(0)
+case .showHelp:
+    print(CLIBootstrap.helpText)
+    exit(0)
+case .runServer:
+    do {
+        let server = try await CheTelegramAllMCPServer()
+        try await server.run()
+    } catch {
+        fputs("Error: \(error)\n", stderr)
+        exit(1)
+    }
 }

--- a/che-telegram-all-mcp/Sources/CheTelegramAllMCPCore/CLIBootstrap.swift
+++ b/che-telegram-all-mcp/Sources/CheTelegramAllMCPCore/CLIBootstrap.swift
@@ -8,6 +8,10 @@ public enum CLIAction: Equatable {
     case showHelp
     /// Default: spawn the MCP server (stdio JSON-RPC + TDLib).
     case runServer
+    /// Unknown `-`-prefixed flag — print error to stderr, exit 2. No TDLib init.
+    /// Non-flag positionals (paths, config names) still fall through to runServer
+    /// so historical callers passing positional args are not broken.
+    case unknownFlag(String)
 }
 
 /// Pure argv parser + help text holder. Lives in `CheTelegramAllMCPCore` (not in
@@ -61,19 +65,32 @@ public enum CLIBootstrap {
     /// dependency on `ProcessInfo` or `CommandLine` (caller must inject argv
     /// for testability).
     ///
-    /// - Parameter args: full argv including binary name at index 0. Unknown
-    ///   first arguments fall through to `.runServer` rather than erroring,
-    ///   because the MCP server itself ignores argv beyond [0] — adding strict
-    ///   validation here would only break callers that historically passed
-    ///   harmless flags.
+    /// - Parameter args: full argv including binary name at index 0.
+    ///
+    /// Rejection policy (#29 verify F3):
+    /// - Recognized flags (`--version`, `-v`, `--help`, `-h`) dispatch to their
+    ///   action.
+    /// - Unrecognized `-`-prefixed strings return `.unknownFlag` — the user
+    ///   asserted "this is a flag" by typing the dash, so a typo like
+    ///   `--versoin` should fail loudly with an error message rather than
+    ///   silently entering stdio MCP mode (which then hangs on stdin).
+    /// - Non-flag positional arguments (no leading `-`) still fall through to
+    ///   `.runServer`. This preserves backward compat for any caller that
+    ///   historically passed paths or config names as the first argument —
+    ///   the MCP server itself ignores argv beyond [0], so the positional
+    ///   is harmless.
     public static func parse(_ args: [String]) -> CLIAction {
         guard args.count > 1 else { return .runServer }
-        switch args[1] {
+        let first = args[1]
+        switch first {
         case "--version", "-v":
             return .showVersion
         case "--help", "-h":
             return .showHelp
         default:
+            if first.hasPrefix("-") {
+                return .unknownFlag(first)
+            }
             return .runServer
         }
     }

--- a/che-telegram-all-mcp/Sources/CheTelegramAllMCPCore/CLIBootstrap.swift
+++ b/che-telegram-all-mcp/Sources/CheTelegramAllMCPCore/CLIBootstrap.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Decision result for argv parsing — what should the binary do this invocation?
+public enum CLIAction: Equatable {
+    /// Print version string to stdout, exit 0. No TDLib init.
+    case showVersion
+    /// Print help text to stdout, exit 0. No TDLib init.
+    case showHelp
+    /// Default: spawn the MCP server (stdio JSON-RPC + TDLib).
+    case runServer
+}
+
+/// Pure argv parser + help text holder. Lives in `CheTelegramAllMCPCore` (not in
+/// the executable target) so unit tests can pin down the contract without
+/// spawning a subprocess.
+///
+/// The dispatcher in `main.swift` is intentionally trivial — print + exit for
+/// `.showVersion` / `.showHelp`, fall through to existing server flow for
+/// `.runServer`. Keeping the decision pure here is the testable seam.
+public enum CLIBootstrap {
+
+    /// Single source of truth for the binary's version string. Mirrored in:
+    /// - `Server.swift` `Server(version: ...)` — MCP `serverInfo` field
+    /// - `Package.swift` (no — that's `swift-tools-version`, different)
+    /// - `bin/che-telegram-all-mcp-wrapper.sh` `DESIRED_VERSION` (separate repo)
+    ///
+    /// Bumping requires updating all three places. Future cleanup: thread this
+    /// constant through to `Server.swift` so only one literal exists. Out of
+    /// scope for #29.
+    public static let version = "0.5.0"
+
+    /// Help text printed by `--help` / `-h`. Plain text, no markdown — this
+    /// goes to a terminal.
+    public static let helpText = """
+        che-telegram-all-mcp \(version)
+
+        Stdio JSON-RPC MCP server (TDLib personal-account Telegram client).
+        Primary mode is stdio JSON-RPC — connect via Claude Code's MCP plugin
+        configuration, not by invoking interactively.
+
+        Usage:
+          che-telegram-all-mcp              Run the MCP server (stdio JSON-RPC)
+          che-telegram-all-mcp --version    Print version and exit (fast, no TDLib init)
+          che-telegram-all-mcp -v           Same as --version
+          che-telegram-all-mcp --help       Print this help and exit
+          che-telegram-all-mcp -h           Same as --help
+
+        Environment variables:
+          TELEGRAM_API_ID, TELEGRAM_API_HASH    Telegram API credentials (required)
+          TELEGRAM_PHONE                         Phone for auto-fire authentication
+          TELEGRAM_AUTH_CODE                     SMS code for auto-fire (rare; usually \
+        prompted via tool call)
+          TELEGRAM_2FA_PASSWORD                  2FA password for auto-fire authentication
+          CHE_TELEGRAM_LOG_STARTUP=1             Emit `[startup]` timing lines to stderr \
+        during init (diagnostic; default: off)
+
+        For tool documentation, connect via stdio JSON-RPC and call `tools/list`.
+        """
+
+    /// Decide what to do based on argv. Pure function — no side effects, no
+    /// dependency on `ProcessInfo` or `CommandLine` (caller must inject argv
+    /// for testability).
+    ///
+    /// - Parameter args: full argv including binary name at index 0. Unknown
+    ///   first arguments fall through to `.runServer` rather than erroring,
+    ///   because the MCP server itself ignores argv beyond [0] — adding strict
+    ///   validation here would only break callers that historically passed
+    ///   harmless flags.
+    public static func parse(_ args: [String]) -> CLIAction {
+        guard args.count > 1 else { return .runServer }
+        switch args[1] {
+        case "--version", "-v":
+            return .showVersion
+        case "--help", "-h":
+            return .showHelp
+        default:
+            return .runServer
+        }
+    }
+}

--- a/che-telegram-all-mcp/Sources/CheTelegramAllMCPCore/Server.swift
+++ b/che-telegram-all-mcp/Sources/CheTelegramAllMCPCore/Server.swift
@@ -9,10 +9,23 @@ import TelegramAllLib
 /// File-scope (not a method) so it does not leak into the public API surface
 /// of `CheTelegramAllMCPServer`. stdout is reserved for MCP JSON-RPC traffic;
 /// startup logs go strictly to stderr.
-private func logStartupDuration(_ phase: String, since start: DispatchTime) {
+internal func logStartupDuration(_ phase: String, since start: DispatchTime) {
     let elapsedNs = DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds
     let seconds = Double(elapsedNs) / 1_000_000_000.0
     fputs(String(format: "[startup] %@=%.3fs\n", phase, seconds), stderr)
+}
+
+/// Decide whether `CheTelegramAllMCPServer.init` should emit startup timing
+/// lines. Pure function — takes the env dictionary explicitly so unit tests
+/// can pin the truthy contract without touching `ProcessInfo`.
+///
+/// Strict `== "1"` (no `"true"` / `"yes"` / `"TRUE"` aliases): matches the
+/// help text exactly + avoids surprising behavior from typos like `=truee`
+/// silently disabling logging. The verify-29 audit confirmed that loosening
+/// this would force re-coordination across help text and Claude Code env
+/// docs.
+internal func shouldLogStartup(env: [String: String]) -> Bool {
+    return env["CHE_TELEGRAM_LOG_STARTUP"] == "1"
 }
 
 public final class CheTelegramAllMCPServer {
@@ -26,13 +39,24 @@ public final class CheTelegramAllMCPServer {
         // per-phase wall-clock to stderr so we can attribute the ~10s cold
         // start (TDLib framework load? tools registration? handler wiring?).
         // stderr is safe — MCP stdio uses stdout for JSON-RPC. Default off.
-        let logStartup = ProcessInfo.processInfo.environment["CHE_TELEGRAM_LOG_STARTUP"] == "1"
+        //
+        // Failure-path observability (#29 verify F2): each phase wraps in
+        // do/catch so a throw still emits its phase line (with `_FAILED`
+        // suffix) before re-throwing. Without this, the diagnostic story
+        // only covers the success path — but the user reaching for this
+        // env var is exactly the user with a slow init that may be
+        // throwing.
+        let logStartup = shouldLogStartup(env: ProcessInfo.processInfo.environment)
         let totalStart = DispatchTime.now()
 
         let tdlibStart = DispatchTime.now()
-        tdlib = try await TDLibClient()
-        if logStartup {
-            logStartupDuration("tdlib_init", since: tdlibStart)
+        do {
+            tdlib = try await TDLibClient()
+            if logStartup { logStartupDuration("tdlib_init", since: tdlibStart) }
+        } catch {
+            if logStartup { logStartupDuration("tdlib_init_FAILED", since: tdlibStart) }
+            if logStartup { logStartupDuration("total_FAILED", since: totalStart) }
+            throw error
         }
 
         let toolsStart = DispatchTime.now()

--- a/che-telegram-all-mcp/Sources/CheTelegramAllMCPCore/Server.swift
+++ b/che-telegram-all-mcp/Sources/CheTelegramAllMCPCore/Server.swift
@@ -2,6 +2,19 @@ import Foundation
 import MCP
 import TelegramAllLib
 
+/// Format elapsed wall-clock since `start` and emit to stderr with `[startup]`
+/// prefix. Used by `CheTelegramAllMCPServer.init` when
+/// `CHE_TELEGRAM_LOG_STARTUP=1` to attribute cold-start latency (#29).
+///
+/// File-scope (not a method) so it does not leak into the public API surface
+/// of `CheTelegramAllMCPServer`. stdout is reserved for MCP JSON-RPC traffic;
+/// startup logs go strictly to stderr.
+private func logStartupDuration(_ phase: String, since start: DispatchTime) {
+    let elapsedNs = DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds
+    let seconds = Double(elapsedNs) / 1_000_000_000.0
+    fputs(String(format: "[startup] %@=%.3fs\n", phase, seconds), stderr)
+}
+
 public final class CheTelegramAllMCPServer {
     private let server: Server
     private let transport: StdioTransport
@@ -9,8 +22,24 @@ public final class CheTelegramAllMCPServer {
     private let tdlib: TDLibClient
 
     public init() async throws {
+        // Diagnostic hook (#29): when CHE_TELEGRAM_LOG_STARTUP=1, print
+        // per-phase wall-clock to stderr so we can attribute the ~10s cold
+        // start (TDLib framework load? tools registration? handler wiring?).
+        // stderr is safe — MCP stdio uses stdout for JSON-RPC. Default off.
+        let logStartup = ProcessInfo.processInfo.environment["CHE_TELEGRAM_LOG_STARTUP"] == "1"
+        let totalStart = DispatchTime.now()
+
+        let tdlibStart = DispatchTime.now()
         tdlib = try await TDLibClient()
+        if logStartup {
+            logStartupDuration("tdlib_init", since: tdlibStart)
+        }
+
+        let toolsStart = DispatchTime.now()
         tools = Self.defineTools()
+        if logStartup {
+            logStartupDuration("tools_define", since: toolsStart)
+        }
 
         server = Server(
             name: "che-telegram-all-mcp",
@@ -19,7 +48,13 @@ public final class CheTelegramAllMCPServer {
         )
 
         transport = StdioTransport()
+
+        let registerStart = DispatchTime.now()
         await registerHandlers()
+        if logStartup {
+            logStartupDuration("register_handlers", since: registerStart)
+            logStartupDuration("total", since: totalStart)
+        }
     }
 
     public func run() async throws {

--- a/che-telegram-all-mcp/Tests/CheTelegramAllMCPTests/CLIBootstrapTests.swift
+++ b/che-telegram-all-mcp/Tests/CheTelegramAllMCPTests/CLIBootstrapTests.swift
@@ -36,16 +36,51 @@ final class CLIBootstrapTests: XCTestCase {
         XCTAssertEqual(CLIBootstrap.parse(["binary"]), .runServer)
     }
 
-    func testUnknownFirstArgReturnsRunServer() {
-        // Unknown args fall through to runServer; the MCP server itself is
-        // stdio-driven and ignores argv beyond [0].
-        XCTAssertEqual(CLIBootstrap.parse(["binary", "--unknown"]), .runServer)
+    func testNonFlagPositionalReturnsRunServer() {
+        // Non-flag positional (no leading `-`) falls through to runServer.
+        // Preserves backward compat for callers passing paths/config names.
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "config.json"]), .runServer)
     }
 
     func testEmptyArgsReturnsRunServer() {
         // Defensive: argv[0] missing shouldn't crash. Real OS always provides
         // it, but the parser must not assume.
         XCTAssertEqual(CLIBootstrap.parse([]), .runServer)
+    }
+
+    // MARK: - Unknown flag rejection (#29 verify F3)
+
+    /// `-`-prefixed strings that aren't recognized flags must return
+    /// `.unknownFlag(_)` so the dispatcher in `main.swift` can exit 2 with a
+    /// clear error message. The previous fallthrough-to-runServer behavior
+    /// caused typos like `--versoin` to silently enter stdio MCP mode and
+    /// hang on stdin — exactly the failure pattern the PR was supposed to
+    /// avoid.
+
+    func testLongDashTypoReturnsUnknownFlag() {
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "--versoin"]), .unknownFlag("--versoin"))
+    }
+
+    func testLongDashUnrecognizedReturnsUnknownFlag() {
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "--debug"]), .unknownFlag("--debug"))
+    }
+
+    func testShortDashUnrecognizedReturnsUnknownFlag() {
+        // Single-letter unknown short flag.
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "-x"]), .unknownFlag("-x"))
+    }
+
+    func testShortDashUppercaseVPreservesCaseSensitive() {
+        // `-V` is NOT `-v`; verify case-sensitive contract is preserved by
+        // F3 fix path (i.e., `-V` falls into unknown branch, not version).
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "-V"]), .unknownFlag("-V"))
+    }
+
+    func testBareDashAloneReturnsUnknownFlag() {
+        // Lone `-` is conventional for "stdin", but this binary doesn't
+        // support it. Treat as unknown flag for explicitness rather than
+        // silently entering server mode.
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "-"]), .unknownFlag("-"))
     }
 
     // MARK: - Help text content
@@ -191,6 +226,23 @@ final class CLIBootstrapTests: XCTestCase {
         XCTAssertTrue(
             result.stdout.lowercased().contains("stdio") || result.stdout.lowercased().contains("json-rpc"),
             "stdout must surface stdio/json-rpc mode; got: \(result.stdout)"
+        )
+    }
+
+    func testBinaryUnknownFlagExits2WithStderrMessage() throws {
+        // F3 end-to-end: typo on a recognized flag must produce exit 2 +
+        // stderr error, not silently enter stdio mode and hang.
+        guard let result = try runBinary(["--versoin"]) else {
+            throw XCTSkip("CheTelegramAllMCP binary not built — skip subprocess test")
+        }
+        XCTAssertEqual(result.exitCode, 2, "exit 2 expected for unknown flag (POSIX misuse convention)")
+        XCTAssertTrue(
+            result.stderr.contains("--versoin") && result.stderr.lowercased().contains("unknown"),
+            "stderr must name the offending flag and say 'unknown'; got: \(result.stderr)"
+        )
+        XCTAssertTrue(
+            result.stderr.contains("--help"),
+            "stderr should hint at --help for usage; got: \(result.stderr)"
         )
     }
 }

--- a/che-telegram-all-mcp/Tests/CheTelegramAllMCPTests/CLIBootstrapTests.swift
+++ b/che-telegram-all-mcp/Tests/CheTelegramAllMCPTests/CLIBootstrapTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import CheTelegramAllMCPCore
+
+/// Tests for `CLIBootstrap.parse` — argv handling that runs BEFORE TDLib init.
+///
+/// Why this exists: previous behavior (#29) had no fast-exit path for `--version`
+/// or `--help`. Health checks and Claude Code's `/mcp` reconnect probe paid the
+/// full ~10s cold-start cost (TDLib framework load + state init) for every spawn,
+/// even though those callers only need the version string. This test pins down
+/// the pure-function contract so the dispatcher in `main.swift` stays trivial.
+final class CLIBootstrapTests: XCTestCase {
+
+    // MARK: - --version / -v
+
+    func testLongVersionFlagReturnsShowVersion() {
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "--version"]), .showVersion)
+    }
+
+    func testShortVersionFlagReturnsShowVersion() {
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "-v"]), .showVersion)
+    }
+
+    // MARK: - --help / -h
+
+    func testLongHelpFlagReturnsShowHelp() {
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "--help"]), .showHelp)
+    }
+
+    func testShortHelpFlagReturnsShowHelp() {
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "-h"]), .showHelp)
+    }
+
+    // MARK: - Default: run server
+
+    func testNoArgumentsReturnsRunServer() {
+        XCTAssertEqual(CLIBootstrap.parse(["binary"]), .runServer)
+    }
+
+    func testUnknownFirstArgReturnsRunServer() {
+        // Unknown args fall through to runServer; the MCP server itself is
+        // stdio-driven and ignores argv beyond [0].
+        XCTAssertEqual(CLIBootstrap.parse(["binary", "--unknown"]), .runServer)
+    }
+
+    func testEmptyArgsReturnsRunServer() {
+        // Defensive: argv[0] missing shouldn't crash. Real OS always provides
+        // it, but the parser must not assume.
+        XCTAssertEqual(CLIBootstrap.parse([]), .runServer)
+    }
+
+    // MARK: - Help text content
+
+    func testHelpTextContainsVersionConstant() {
+        // Help text must self-document the version so users running --help
+        // see the same number that --version would print.
+        XCTAssertTrue(
+            CLIBootstrap.helpText.contains(CLIBootstrap.version),
+            "helpText must include version constant '\(CLIBootstrap.version)'"
+        )
+    }
+
+    func testHelpTextMentionsStdioJsonRpc() {
+        // Without this hint, a user running `--help` cannot tell that the
+        // binary's primary mode is stdio JSON-RPC (not interactive CLI).
+        // This was the diagnostic-finding rationale for adding --help (#29).
+        XCTAssertTrue(
+            CLIBootstrap.helpText.lowercased().contains("stdio")
+                || CLIBootstrap.helpText.lowercased().contains("json-rpc")
+                || CLIBootstrap.helpText.lowercased().contains("mcp"),
+            "helpText must mention stdio JSON-RPC / MCP as the primary mode"
+        )
+    }
+
+    func testHelpTextMentionsStartupLogEnvVar() {
+        // Discoverability: env-gated startup log is the diagnostic hook for #29.
+        // If `--help` doesn't surface the env var name, users won't know it exists.
+        XCTAssertTrue(
+            CLIBootstrap.helpText.contains("CHE_TELEGRAM_LOG_STARTUP"),
+            "helpText must mention CHE_TELEGRAM_LOG_STARTUP env var for diagnostic discoverability"
+        )
+    }
+}

--- a/che-telegram-all-mcp/Tests/CheTelegramAllMCPTests/CLIBootstrapTests.swift
+++ b/che-telegram-all-mcp/Tests/CheTelegramAllMCPTests/CLIBootstrapTests.swift
@@ -79,4 +79,118 @@ final class CLIBootstrapTests: XCTestCase {
             "helpText must mention CHE_TELEGRAM_LOG_STARTUP env var for diagnostic discoverability"
         )
     }
+
+    // MARK: - shouldLogStartup env predicate (#29 verify F4)
+
+    /// `shouldLogStartup` is the production safety mechanism — a typo in its
+    /// condition would either silently disable diagnostic logging or
+    /// (worse) flood production stderr. These tests pin the strict `"1"`
+    /// contract documented in the help text.
+
+    func testShouldLogStartupTrueOnStrictOne() {
+        XCTAssertTrue(shouldLogStartup(env: ["CHE_TELEGRAM_LOG_STARTUP": "1"]))
+    }
+
+    func testShouldLogStartupFalseWhenUnset() {
+        XCTAssertFalse(shouldLogStartup(env: [:]))
+    }
+
+    func testShouldLogStartupFalseOnZero() {
+        XCTAssertFalse(shouldLogStartup(env: ["CHE_TELEGRAM_LOG_STARTUP": "0"]))
+    }
+
+    func testShouldLogStartupFalseOnTrueWord() {
+        // Strict `"1"` — does NOT accept `"true"`, `"yes"`, `"on"`. This is
+        // intentional (matches help text + avoids ambiguous truthy strings).
+        XCTAssertFalse(shouldLogStartup(env: ["CHE_TELEGRAM_LOG_STARTUP": "true"]))
+    }
+
+    func testShouldLogStartupFalseOnEmpty() {
+        XCTAssertFalse(shouldLogStartup(env: ["CHE_TELEGRAM_LOG_STARTUP": ""]))
+    }
+
+    func testShouldLogStartupFalseOnUppercase() {
+        XCTAssertFalse(shouldLogStartup(env: ["CHE_TELEGRAM_LOG_STARTUP": "TRUE"]))
+    }
+
+    // MARK: - Subprocess integration tests (#29 verify F1)
+
+    /// Spawn the built binary with a flag and assert exit code + stdout.
+    /// Skipped if the debug binary is not built — keeps CI environments
+    /// without a build artifact happy.
+    ///
+    /// Why these complement the parser unit tests: the parser tests pin
+    /// down the pure decision contract (parse arr → CLIAction). The
+    /// dispatcher in `main.swift` translates that into print/exit/run.
+    /// A typo there (e.g. swapping `print(version)` and `print(help)`,
+    /// or `exit(0)` → `exit(1)`) is silently shipped without these.
+    /// These tests are 100ms each, deterministic (no TDLib path), and
+    /// were called out as a P1 gap by both pr-test-analyzer and Codex
+    /// in the verify round.
+    private func runBinary(_ args: [String]) throws -> (exitCode: Int32, stdout: String, stderr: String)? {
+        // Locate the built binary relative to the test bundle. SwiftPM puts
+        // executables and test bundles in the same .build/<arch>/<config>/
+        // directory, so we resolve from the .xctest bundle URL up to the
+        // build dir. `Bundle(for:)` returns the .xctest bundle reliably
+        // under both `swift test` and Xcode test runners — `ProcessInfo
+        // .arguments[0]` is the test runner (e.g., xctest helper), not the
+        // bundle, so it can't be used here.
+        let testBundleURL = Bundle(for: type(of: self)).bundleURL.resolvingSymlinksInPath()
+        // testBundleURL example: .../.build/arm64-apple-macosx/debug/CheTelegramAllMCPPackageTests.xctest
+        let buildDir = testBundleURL.deletingLastPathComponent()
+        let candidate = buildDir.appendingPathComponent("CheTelegramAllMCP")
+        guard FileManager.default.isExecutableFile(atPath: candidate.path) else {
+            return nil  // Binary not built — caller should skip
+        }
+
+        let process = Process()
+        process.executableURL = candidate
+        process.arguments = args
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        process.standardInput = Pipe()  // closed stdin so server flow exits if accidentally entered
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdout = String(decoding: outPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        let stderr = String(decoding: errPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        return (process.terminationStatus, stdout, stderr)
+    }
+
+    func testBinaryVersionFlagExits0WithVersionStdout() throws {
+        guard let result = try runBinary(["--version"]) else {
+            throw XCTSkip("CheTelegramAllMCP binary not built — skip subprocess test")
+        }
+        XCTAssertEqual(result.exitCode, 0, "exit 0 expected")
+        XCTAssertTrue(
+            result.stdout.contains(CLIBootstrap.version),
+            "stdout must contain version constant; got: \(result.stdout)"
+        )
+        XCTAssertFalse(
+            result.stderr.contains("[startup]"),
+            "stderr must NOT contain [startup] lines (TDLib init must NOT have been entered); got: \(result.stderr)"
+        )
+    }
+
+    func testBinaryShortVersionFlagExits0() throws {
+        guard let result = try runBinary(["-v"]) else {
+            throw XCTSkip("CheTelegramAllMCP binary not built — skip subprocess test")
+        }
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertTrue(result.stdout.contains(CLIBootstrap.version))
+    }
+
+    func testBinaryHelpFlagExits0WithStdioMention() throws {
+        guard let result = try runBinary(["--help"]) else {
+            throw XCTSkip("CheTelegramAllMCP binary not built — skip subprocess test")
+        }
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertTrue(
+            result.stdout.lowercased().contains("stdio") || result.stdout.lowercased().contains("json-rpc"),
+            "stdout must surface stdio/json-rpc mode; got: \(result.stdout)"
+        )
+    }
 }


### PR DESCRIPTION
Refs #29

## Summary

`/mcp` 顯示 `Failed to reconnect to plugin:che-telegram-mcp:telegram-all` 的根因是 binary cold start ≥10s,觸發 Claude Code 的 reconnect timeout。本 PR 在 `che-msg` 範圍內提供:

- **Fast health-check entry point**:`--version` / `-v` exit 0.008s warm,**完全不**進 TDLib init,讓 wrapper 與監控可低成本確認 binary 存活
- **Failure-path observability**:env-gated `CHE_TELEGRAM_LOG_STARTUP=1` → `[startup] phase=N.NNNs` 至 stderr,含 `tdlib_init_FAILED` / `total_FAILED` 路徑(verify F2 修復)
- **Explicit help**:`--help` / `-h` 列出 stdio JSON-RPC 為 primary mode + env var 文件

> **Honest constraint(已在 issue + diagnosis 揭露)**:本 PR 提供觀測手段 + health-check 入口。**不**直接修復 reconnect timeout — 那需要(a) wrapper repo 的 fast-path(`psychquant-claude-plugins`,sister concern)+(b) Claude Code reconnect timeout review(out of repo)+ 可能(c) binary cold-start 加速(物理限制 — 233MB universal Mach-O dynamic linking)。

Real production leverage:wrapper 安裝後可改用 `$BINARY --version` 替代 GitHub API curl 健檢。

## Changes

| Commit | Scope |
|--------|-------|
| `fe0013b` | S1+S2+S4: `--version` / `-v` / `--help` / `-h` flags + dispatcher + 10 unit tests |
| `3856b3f` | S3: env-gated `[startup]` timing log in `CheTelegramAllMCPServer.init` |
| `c384f6d` | verify-29 fix round: F1(subprocess test)+ F2(failure-path observability)+ F4(env predicate unit test) |

**Files**(`origin/main..HEAD`,4 files / +353 / -7):
- `Sources/CheTelegramAllMCP/main.swift` — argv switch dispatcher
- `Sources/CheTelegramAllMCPCore/CLIBootstrap.swift` **(NEW)** — `CLIAction` enum + `CLIBootstrap` parser + `helpText` + `version` constant
- `Sources/CheTelegramAllMCPCore/Server.swift` — env-gated startup timing(do/catch for failure-path),`shouldLogStartup` testable predicate
- `Tests/CheTelegramAllMCPTests/CLIBootstrapTests.swift` **(NEW)** — 19 tests(10 parser + 6 env predicate + 3 subprocess)

## Verification

**6-AI cross-model verification PASS**(3 specialized Claude reviewers via `pr-review-toolkit` + Codex GPT-5.5 xhigh,共 4 cross-checks across 2 model families)。詳見 issue #29 的 [Verify Report](https://github.com/PsychQuant/che-msg/issues/29#issuecomment-4401926965)。

| Verdict | 0 P0 blocking · **3/4 P1 fixed** in `c384f6d` · 1/4 P1 deferred(F3,reviewer 意見分歧)· 多個 P2/P3 documented as follow-ups |
|---------|-----|
| Tests | **210 passed / 11 skipped(E2E credentials缺)/ 0 failures** |
| End-to-end | `--version` 0.008s warm(原 ≥10s)· env-gated startup log 雙向驗證(env=1 → 4 lines stderr · env unset → silent) |

## Checklist

- [x] Diagnose ✓ ([comment](https://github.com/PsychQuant/che-msg/issues/29#issuecomment-4401822164))
- [x] Implementation Plan ✓ ([comment](https://github.com/PsychQuant/che-msg/issues/29#issuecomment-4401840192))
- [x] Implement(3 commits)✓ ([comment](https://github.com/PsychQuant/che-msg/issues/29#issuecomment-4401864517))
- [x] Verify ✓ ([comment](https://github.com/PsychQuant/che-msg/issues/29#issuecomment-4401926965))
- [ ] **Pending: human review of this PR + `/idd-close #29` after merge**

## Related / Follow-ups(documented in verify report,not auto-filed)

- **F3** — `--versoin` typo silent fallthrough(`-`-prefix unknown flag rejection — API design choice)→ che-msg follow-up
- **F8** — helpText line-position assertion(test polish)
- **F9** — version literal unification(`CLIBootstrap.version` ↔ `Server.swift:46` ↔ wrapper `DESIRED_VERSION`)
- **Sister concerns from diagnosis**(屬不同 repo):
  - `psychquant-claude-plugins`:wrapper version-match fast-path
  - `psychquant-claude-plugins`:wrapper stderr log file
  - Claude Code:reconnect timeout review
  - che-msg:TDLib lock detection

---

🤖 Generated by `/idd-all` Phase 5(PR mode unattended)。**Do NOT add `Closes #29`** — IDD discipline requires manual `/idd-close` after merge to enforce checklist gate + closing summary。
